### PR TITLE
enum/one-of vereinheitlichen

### DIFF
--- a/i1gem.tex
+++ b/i1gem.tex
@@ -356,7 +356,7 @@ Eine Konstruktionsanleitung oder Schablone für gemischte Daten
 des entsprechenden Falls.
 
 Beachte den Unterschied zwischen \lstinline{enum} und
-\lstinline{mixed}, die leicht zu verwechseln sind: \lstinline{One-of} steht
+\lstinline{mixed}, die leicht zu verwechseln sind: \lstinline{enum} steht
 für "<einer der folgenden \emph{Werte}">, während \lstinline{mixed} für
 "<gehörend zu einer der folgenden \emph{Signaturen}"> steht.
 


### PR DESCRIPTION
Sollte es nicht beide Male `enum` heissen?